### PR TITLE
fix(ci): add build step before npm publish

### DIFF
--- a/.changeset/fix-publish-build.md
+++ b/.changeset/fix-publish-build.md
@@ -1,0 +1,5 @@
+---
+'@side-quest/core': patch
+---
+
+fix(ci): add build step before npm publish in changesets workflow

--- a/.github/scripts/changesets-publish.sh
+++ b/.github/scripts/changesets-publish.sh
@@ -57,6 +57,9 @@ else
   annotate notice "Ensure trusted publisher is configured at: npmjs.com → package Settings → Trusted Publisher"
 fi
 
+annotate notice "Building before publish."
+bun run build
+
 annotate notice "Attempting publish via 'bun run release'."
 
 # Run the project's publish script (configured to call `changeset publish`)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -167,8 +167,8 @@ jobs:
           TAG="v${VERSION}"
           echo "Creating GitHub release for ${TAG}"
           # Create and push the tag (Changesets doesn't create tags)
-          git tag "${TAG}"
-          git push origin "${TAG}"
+          git tag "${TAG}" 2>/dev/null || echo "Tag ${TAG} already exists"
+          git push origin "${TAG}" 2>/dev/null || echo "Tag ${TAG} already pushed"
           # Create the release
           gh release create "${TAG}" \
             --title "${TAG}" \


### PR DESCRIPTION
## Summary
- Add `bun run build` before `bun run release` in the changesets publish script
- Make GitHub release tag step idempotent (don't fail if tag exists)
- Includes patch changeset to trigger a republish with dist/ included

The 0.1.0 publish was empty (no dist/) because the auto-publish path didn't build.