### PR TITLE
fix(ci): write npm auth to NPM_CONFIG_USERCONFIG path

### DIFF
--- a/.github/scripts/changesets-publish.sh
+++ b/.github/scripts/changesets-publish.sh
@@ -38,17 +38,21 @@ if [[ -n "${NPM_TOKEN:-}" ]]; then
   # Fallback: use NPM_TOKEN (for bootstrap or if OIDC not configured)
   annotate notice "NPM_TOKEN detected; using token auth (fallback mode)."
 
+  # Determine which .npmrc to write to. setup-node sets NPM_CONFIG_USERCONFIG
+  # to a temp file that overrides ~/.npmrc, so we must write there if it exists.
+  NPMRC="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+
   # Trap to ensure cleanup on exit
-  trap 'rm -f "$HOME/.npmrc"' EXIT
+  trap 'rm -f "$NPMRC"' EXIT
 
   # Authenticate npm for publish
   {
     echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
-  } > "$HOME/.npmrc"
-  chmod 0600 "$HOME/.npmrc"
+  } > "$NPMRC"
+  chmod 0600 "$NPMRC"
 
   echo "::group::Configure npm auth"
-  echo "Wrote npm auth token to ~/.npmrc"
+  echo "Wrote npm auth token to ${NPMRC}"
   echo "::endgroup::"
 else
   # Primary: OIDC trusted publishing (no token needed)


### PR DESCRIPTION
## Summary

- Write NPM_TOKEN to `NPM_CONFIG_USERCONFIG` path instead of `~/.npmrc`
- `setup-node` with `registry-url` sets `NPM_CONFIG_USERCONFIG` to a temp `.npmrc` that overrides `~/.npmrc`
- Discovered during side-quest-x-api publish debugging — core hasn't hit this yet because it doesn't have pending changesets, but will on next publish

## Test plan

- [ ] Merge PR
- [ ] Next changeset-triggered publish uses correct npmrc path