### PR TITLE
chore: sync infrastructure from bun-typescript-starter

### DIFF
--- a/.github/scripts/changesets-publish.sh
+++ b/.github/scripts/changesets-publish.sh
@@ -61,7 +61,7 @@ else
   annotate notice "Ensure trusted publisher is configured at: npmjs.com → package Settings → Trusted Publisher"
 fi
 
-annotate notice "Building before publish."
+annotate notice "Building before publish..."
 bun run build
 
 annotate notice "Attempting publish via 'bun run release'."

--- a/.github/workflows/alpha-snapshot.yml
+++ b/.github/workflows/alpha-snapshot.yml
@@ -44,7 +44,7 @@ jobs:
         uses: ./.github/actions/setup-bun
       - name: Setup Node for npm publish
         if: steps.pre.outputs.active == 'true'
-        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: '24'  # Node 24 includes npm 11.6+ (required for OIDC trusted publishing)
           registry-url: 'https://registry.npmjs.org/'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -39,6 +39,7 @@ jobs:
               'pnpm-lock.yaml',
               'package-lock.json',
               'yarn.lock',
+              'bun.lock',
             ]
             const onlyAllowed = filenames.every(f => allowed.includes(f))
             if (!onlyAllowed) {

--- a/.github/workflows/node-compat.yml
+++ b/.github/workflows/node-compat.yml
@@ -39,7 +39,7 @@ jobs:
         run: bun run build
 
       - name: Setup Node.js
-        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -87,13 +87,10 @@ jobs:
           # Delete all top-level directories containing @@@* anywhere
           find . -maxdepth 1 -type d -name '*@@@*' -exec rm -rf {} + 2>/dev/null || true
 
-          # Delete scoped packages leaked to root (e.g., @changesets, @babel)
-          find . -maxdepth 1 -type d -name '@*' ! -name '.@*' -exec rm -rf {} + 2>/dev/null || true
-
           # Delete any remaining package-like folders (name@version pattern)
           find . -maxdepth 1 -type d -regex '.*/[a-z].*@[0-9].*' -exec rm -rf {} + 2>/dev/null || true
 
-          rm -rf node_modules/.bun node_modules/.old_modules* 2>/dev/null || true
+          rm -rf node_modules/.old_modules* 2>/dev/null || true
 
           # Verify cleanup
           REMAINING=$(find . -maxdepth 1 -type d ! -name '.' | grep -Evc "^\./($KNOWN_DIRS)$" || echo 0)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,13 +77,23 @@ jobs:
         uses: ./.github/actions/setup-bun
 
       - name: Setup Node for npm publish
-        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: '24' # Node 24 includes npm 11.6+ (required for OIDC trusted publishing)
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Ensure changesets CLI is Node-resolvable
+        run: |
+          # The changesets/action uses Node.js require() internally.
+          # Bun's module layout uses .bun/ symlinks that the action's bundled JS
+          # runtime cannot resolve. npm install --no-save also fails because npm
+          # can't parse Bun's node_modules layout.
+          # Solution: install into a separate prefix and add to NODE_PATH.
+          npm install --prefix .npm-changesets @changesets/cli @changesets/changelog-github
+          echo "NODE_PATH=$(pwd)/.npm-changesets/node_modules" >> "$GITHUB_ENV"
 
       - name: Fix conflicting registry in bunfig.toml
         run: |
@@ -99,9 +109,8 @@ jobs:
           # Bun 1.3.x hoisted linker leaks packages to project root
           # Delete @@@* suffixed folders, scoped packages (@*), and versioned packages
           find . -maxdepth 1 -type d -name '*@@@*' -exec rm -rf {} + 2>/dev/null || true
-          find . -maxdepth 1 -type d -name '@*' ! -name '.@*' -exec rm -rf {} + 2>/dev/null || true
           find . -maxdepth 1 -type d -regex '.*/[a-z].*@[0-9].*' -exec rm -rf {} + 2>/dev/null || true
-          rm -rf node_modules/.bun node_modules/.old_modules* 2>/dev/null || true
+          rm -rf node_modules/.old_modules* 2>/dev/null || true
 
       - name: Disable git hooks for CI commits
         run: git config --global core.hooksPath /dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           registry-url: 'https://registry.npmjs.org'
       - name: Setup Node for npm publish
-        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: '24'  # Node 24 includes npm 11.6+ (required for OIDC trusted publishing)
           registry-url: 'https://registry.npmjs.org/'

--- a/biome.json
+++ b/biome.json
@@ -69,9 +69,6 @@
 						"noExplicitAny": "off",
 						"noTemplateCurlyInString": "off"
 					},
-					"correctness": {
-						"noUnusedFunctionParameters": "off"
-					},
 					"complexity": {
 						"noCommaOperator": "off"
 					}


### PR DESCRIPTION
## Summary

- Dynamic package name discovery in changeset generation script (monorepo support)
- Bump `actions/setup-node` v6.1.0 -> v6.2.0 across all workflows
- Add `bun.lock` to dependabot auto-merge allowed lockfiles
- Fix Bun hoisted linker cleanup rules in pr-quality and publish workflows
- Add Node-resolvable changesets CLI step in publish workflow
- Re-enable `noUnusedFunctionParameters` biome rule

## Test plan

- [ ] CI passes (lint, types, tests)
- [ ] Verify changeset generation works for monorepo packages
- [ ] Verify publish workflow succeeds on next release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions tooling to latest versions for improved CI/CD reliability
  * Enhanced multi-package support in the release process
  * Expanded dependency manifest detection in automated merge workflows
  * Refined build artifact cleanup logic

* **Tests**
  * Adjusted linter configuration to better reflect test-file requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->