### PR TITLE
chore: add changeset for extract-reusable-patterns

### DIFF
--- a/.changeset/extract-reusable-patterns.md
+++ b/.changeset/extract-reusable-patterns.md
@@ -1,0 +1,12 @@
+---
+"@side-quest/core": minor
+---
+
+Add reusable validation, spawn, and fs utilities extracted from voice-memo plugin
+
+- `isSafeFilename` / `validateFilename` - whitelist-based filename validation with optional extension matching
+- `validateAbsoluteFilePath` - defense-in-depth absolute path validation (shell metachar rejection, existence, extension)
+- `SHELL_METACHARACTERS_STRICT` - broader metacharacter pattern blocking parens and quotes
+- `isToolAvailable` / `ensureToolAvailable` - async tool detection with actionable install hints
+- `loadJsonStateSync` / `saveJsonStateSync` / `updateJsonFileAtomic` - Zod-validated JSON state management with atomic writes and file locking
+- `isSymlinkSync` / `isEmptyFileSync` - lightweight filesystem helpers


### PR DESCRIPTION
## Summary

Adds the missing changeset for PR #16 (feat: extract reusable patterns from voice-memo plugin).

The CI auto-generated changeset was lost during squash merge. This triggers the `minor` version bump for the new public API surface.

## Test plan

- [ ] Merge triggers "Version Packages" PR from changesets