### PR TITLE
chore(ci): sync 4 template fixes from bun-typescript-starter

### DIFF
--- a/.github/scripts/changeset-detect-existing.sh
+++ b/.github/scripts/changeset-detect-existing.sh
@@ -13,7 +13,7 @@ count_changesets() {
   if [[ -d "$dir" ]]; then
     while IFS= read -r -d '' _file; do
       count=$((count + 1))
-    done < <(find "$dir" -type f -name '*.md' -print0 2>/dev/null)
+    done < <(find "$dir" -type f -name '*.md' -not -name 'README.md' -print0 2>/dev/null)
   fi
   printf '%d\n' "$count"
 }

--- a/.github/scripts/changeset-generate-if-missing.sh
+++ b/.github/scripts/changeset-generate-if-missing.sh
@@ -58,11 +58,11 @@ fi
 
 mkdir -p .changeset
 {
-  printf '---\n'
+  printf '%s\n' '---'
   while IFS= read -r PKG; do
     printf '"%s": %s\n' "$PKG" "$TYPE"
   done <<< "$PACKAGES"
-  printf '---\n\n'
+  printf '%s\n\n' '---'
   printf '%s\n' "$TITLE"
 } >"$FILE"
 

--- a/.github/workflows/version-packages-auto-merge.yml
+++ b/.github/workflows/version-packages-auto-merge.yml
@@ -49,3 +49,21 @@ jobs:
               }
             `, { prId: pr.node_id })
             core.info('Auto-merge enabled for Version Packages PR')
+
+      # GITHUB_TOKEN PRs don't trigger workflows (GitHub anti-recursion).
+      # Dispatch pr-quality.yml using the App token so the required "All
+      # checks passed" gate job runs and branch protection is satisfied.
+      - name: Trigger PR quality checks on version branch
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const branch = context.payload.pull_request.head.ref
+            core.info(`Dispatching PR quality workflow on ${branch}`)
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'pr-quality.yml',
+              ref: branch,
+            })
+            core.info('PR quality workflow dispatched')

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -11,3 +11,21 @@ if [ "$current_branch" = "main" ] || [ "$current_branch" = "master" ]; then
     exit 1
   fi
 fi
+
+# Remind users to enable branch protection (one-time, non-blocking).
+# Once verified, creates a marker file so it never checks again.
+MARKER=".husky/.protection-verified"
+if [ ! -f "$MARKER" ] && command -v gh >/dev/null 2>&1; then
+  repo=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || true)
+  if [ -n "$repo" ]; then
+    if gh api "repos/$repo/branches/main/protection" >/dev/null 2>&1; then
+      mkdir -p .husky
+      touch "$MARKER"
+    else
+      echo ""
+      echo "WARNING: Branch protection is not enabled on main."
+      echo "Run 'bun run setup:protect' to enable it."
+      echo ""
+    fi
+  fi
+fi


### PR DESCRIPTION
## Summary

- **changeset-detect-existing.sh**: Exclude `README.md` from changeset count (`.changeset/README.md` was being counted as a changeset file, potentially skipping auto-generation)
- **changeset-generate-if-missing.sh**: Use portable `printf '%s\n'` format for YAML frontmatter dashes (`printf '---\n'` is non-portable)
- **version-packages-auto-merge.yml**: Dispatch `pr-quality.yml` on version PR branch (GITHUB_TOKEN PRs don't trigger workflows due to GitHub anti-recursion, so this uses the App token)
- **pre-push hook**: Add one-time branch protection reminder (non-blocking warning if protection isn't enabled, creates marker file after first check)

## Test plan

- [x] `bun run validate` passes (lint, typecheck, build, 1226 tests)
- [ ] Visual review of the 4 diffs