### PR TITLE
fix: gitignore .husky/.protection-verified marker file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ report.*.json
 # OS
 .DS_Store
 
+# Husky local markers
+.husky/.protection-verified
+
 # Claude Code local memory
 CLAUDE.local.md
 


### PR DESCRIPTION
## Summary

- Add `.husky/.protection-verified` to `.gitignore` so the local-only branch protection marker file isn't tracked

Upstream issue: https://github.com/nathanvale/bun-typescript-starter/issues/53

## Test plan

- [x] `git status` no longer shows the marker as untracked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development configuration to exclude Husky local markers from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->