### PR TITLE
feat(core): add publishable API catalog artifacts and catalog subpath export

### DIFF
--- a/.changeset/add-api-catalog-artifacts.md
+++ b/.changeset/add-api-catalog-artifacts.md
@@ -1,0 +1,12 @@
+---
+'@side-quest/core': minor
+---
+
+Add publishable API catalog artifacts and subpath exports
+
+- `dist/catalog.json` - structured JSON catalog of all 25 modules, 395+ declarations with signatures, descriptions, and export names
+- `dist/catalog.js` + `dist/catalog.d.ts` - typed JS wrapper for Bun/Node ESM consumption via `@side-quest/core/catalog`
+- `dist/llms.txt` - llms.txt community standard file for LLM ecosystem tooling
+- `@side-quest/core/catalog` subpath export (typed, runtime-safe for both Bun and Node)
+- `@side-quest/core/catalog.json` subpath export (direct JSON access)
+- Catalog generation now filters to package.json-declared module exports only, preventing accidental dist/src noise

--- a/package.json
+++ b/package.json
@@ -109,6 +109,11 @@
 			"types": "./dist/src/mcp-response/index.d.ts",
 			"import": "./dist/src/mcp-response/index.js"
 		},
+		"./catalog": {
+			"types": "./dist/catalog.d.ts",
+			"import": "./dist/catalog.js"
+		},
+		"./catalog.json": "./dist/catalog.json",
 		"./package.json": "./package.json"
 	},
 	"files": [
@@ -140,6 +145,7 @@
 	"sideEffects": false,
 	"scripts": {
 		"build": "bunx bunup",
+		"postbuild": "bun scripts/generate-catalog.ts",
 		"check": "biome check --write .",
 		"check:publint": "publint",
 		"check:types": "attw --pack",

--- a/scripts/generate-catalog.test.ts
+++ b/scripts/generate-catalog.test.ts
@@ -1,0 +1,426 @@
+import { describe, expect, it } from 'bun:test'
+import { existsSync, readFileSync } from 'node:fs'
+import {
+	type Catalog,
+	cleanSignature,
+	extractModuleSummary,
+	generateCatalog,
+	generateCatalogModuleDts,
+	generateCatalogModuleJs,
+	generateLlmsTxt,
+	getExpectedModuleNamesFromPackageExports,
+	getJsdocDescription,
+	hasCatalogSkip,
+	parseDeclarations,
+	parseJsExportBindings,
+	validateFunctionJsdoc,
+} from './generate-catalog.ts'
+
+describe('extractModuleSummary', () => {
+	it('extracts first descriptive line from JSDoc block', () => {
+		const source = `/**
+ * Concurrency utilities for safe concurrent operations.
+ *
+ * Provides primitives for file locking, transactional operations.
+ *
+ * @module core/concurrency
+ */
+
+export { withFileLock } from './file-lock.js'`
+
+		expect(extractModuleSummary(source)).toBe(
+			'Concurrency utilities for safe concurrent operations.',
+		)
+	})
+
+	it('skips @module tags and code fences', () => {
+		const source = `/**
+ * @module core/fs
+ *
+ * Filesystem utilities for Bun-native operations.
+ *
+ * @example
+ * \`\`\`ts
+ * import { readFile } from "@side-quest/core/fs";
+ * \`\`\`
+ */`
+
+		expect(extractModuleSummary(source)).toBe('Filesystem utilities for Bun-native operations.')
+	})
+
+	it('returns empty string when no JSDoc block exists', () => {
+		const source = `export { something } from './something.js'`
+		expect(extractModuleSummary(source)).toBe('')
+	})
+
+	it('skips headings and bold feature lists', () => {
+		const source = `/**
+ * Terminal module - CLI output formatting using Bun's native APIs
+ *
+ * ## Key Features
+ *
+ * - **Color** formatting with Bun.color()
+ * - **String width** calculation
+ */`
+
+		expect(extractModuleSummary(source)).toBe(
+			"Terminal module - CLI output formatting using Bun's native APIs",
+		)
+	})
+})
+
+describe('hasCatalogSkip', () => {
+	it('detects @catalog-skip in JSDoc', () => {
+		expect(hasCatalogSkip('/** @catalog-skip */')).toBe(true)
+		expect(hasCatalogSkip('/** @catalog-skip - Use color() instead */')).toBe(true)
+	})
+
+	it('returns false when not present', () => {
+		expect(hasCatalogSkip('/** Apply bold style to text */')).toBe(false)
+	})
+})
+
+describe('getJsdocDescription', () => {
+	it('walks backwards to find description, skips code examples and tags', () => {
+		const content = `/**
+* Execute an operation with exclusive file lock.
+*
+* Prevents concurrent modifications to the same resource.
+*
+* @param resourceId - Unique identifier
+* @returns Result of the operation
+*
+* @example
+* \`\`\`typescript
+* await withFileLock("registry", async () => { ... });
+* \`\`\`
+*/
+declare function withFileLock<T>(resourceId: string): Promise<T>;`
+
+		const lines = content.split('\n')
+		const declIdx = lines.findIndex((l) => l.includes('declare function'))
+		expect(getJsdocDescription(lines, declIdx)).toBe(
+			'Execute an operation with exclusive file lock.',
+		)
+	})
+
+	it('returns empty string when no JSDoc block above declaration', () => {
+		const content = `declare function orphan(): void;`
+		const lines = content.split('\n')
+		expect(getJsdocDescription(lines, 0)).toBe('')
+	})
+
+	it('skips @param and @returns tags', () => {
+		const content = `/**
+* Format bytes to human-readable size.
+*
+* @param bytes - Number of bytes
+* @returns Human-readable string
+*/
+declare function formatBytes(bytes: number): string;`
+
+		const lines = content.split('\n')
+		const declIdx = lines.findIndex((l) => l.includes('declare function'))
+		expect(getJsdocDescription(lines, declIdx)).toBe('Format bytes to human-readable size.')
+	})
+})
+
+describe('parseDeclarations', () => {
+	it('finds function/class/enum/const declarations', () => {
+		const dts = `declare function doStuff(x: string): boolean;
+declare class MyClass {
+}
+declare enum OutputFormat {
+	JSON = "json"
+}
+declare const SOME_VALUE = "hello";`
+
+		const result = parseDeclarations(dts)
+		expect(result).toHaveLength(4)
+		expect(result.map((d) => d.kind)).toEqual(['function', 'class', 'enum', 'const'])
+		expect(result.map((d) => d.name)).toEqual(['doStuff', 'MyClass', 'OutputFormat', 'SOME_VALUE'])
+	})
+
+	it('does NOT include type or interface declarations', () => {
+		const dts = `type Foo = string;
+interface Bar { x: number; }
+declare function realExport(): void;`
+
+		const result = parseDeclarations(dts)
+		expect(result).toHaveLength(1)
+		expect(result[0]?.name).toBe('realExport')
+	})
+
+	it('deduplicates function overloads by name', () => {
+		const dts = `/**
+* Register a resource (URI variant).
+*/
+declare function resource(name: string, uri: string): void;
+declare function resource(name: string, template: object): void;`
+
+		const result = parseDeclarations(dts)
+		expect(result).toHaveLength(1)
+		expect(result[0]?.name).toBe('resource')
+	})
+
+	it('handles multi-line declare const with object types', () => {
+		const dts = `declare const BOX: {
+	readonly topLeft: "a";
+	readonly topRight: "b";
+};`
+
+		const result = parseDeclarations(dts)
+		expect(result).toHaveLength(1)
+		expect(result[0]?.name).toBe('BOX')
+		expect(result[0]?.signature).toContain('{ ... }')
+	})
+
+	it('skips declarations with @catalog-skip in JSDoc', () => {
+		const dts = `/** @catalog-skip */
+declare const RESET = "\\x1b[0m";
+/**
+* Format a color as ANSI escape code for terminal output.
+*/
+declare function color(input: string): string;`
+
+		const result = parseDeclarations(dts)
+		expect(result).toHaveLength(1)
+		expect(result[0]?.name).toBe('color')
+	})
+
+	it('extracts description from preceding JSDoc', () => {
+		const dts = `/**
+* Execute an operation with exclusive file lock.
+*
+* @param resourceId - The resource to lock
+*/
+declare function withFileLock(resourceId: string): Promise<void>;`
+
+		const result = parseDeclarations(dts)
+		expect(result[0]?.description).toBe('Execute an operation with exclusive file lock.')
+	})
+})
+
+describe('parseJsExportBindings', () => {
+	it('parses plain and aliased exports from generated JS', () => {
+		const js = `export { tool, startServer, unescapeGitPath2 as unescapeGitPath, z };`
+		expect(parseJsExportBindings(js)).toEqual([
+			{ local: 'tool', exported: 'tool' },
+			{ local: 'startServer', exported: 'startServer' },
+			{ local: 'unescapeGitPath2', exported: 'unescapeGitPath' },
+			{ local: 'z', exported: 'z' },
+		])
+	})
+
+	it('parses multiline export lists', () => {
+		const js = `export {
+  existsSync,
+  fsCopyFileSync as nodeCopyFileSync,
+  readFileSync
+};`
+		expect(parseJsExportBindings(js)).toEqual([
+			{ local: 'existsSync', exported: 'existsSync' },
+			{ local: 'fsCopyFileSync', exported: 'nodeCopyFileSync' },
+			{ local: 'readFileSync', exported: 'readFileSync' },
+		])
+	})
+})
+
+describe('getExpectedModuleNamesFromPackageExports', () => {
+	it('returns module names from dist/src import targets', () => {
+		const exportsField = {
+			'./fs': {
+				types: './dist/src/fs/index.d.ts',
+				import: './dist/src/fs/index.js',
+			},
+			'./mcp-response': {
+				types: './dist/src/mcp-response/index.d.ts',
+				import: './dist/src/mcp-response/index.js',
+			},
+			'./catalog': {
+				types: './dist/catalog.d.ts',
+				import: './dist/catalog.js',
+			},
+			'./catalog.json': './dist/catalog.json',
+			'./package.json': './package.json',
+		}
+
+		expect(getExpectedModuleNamesFromPackageExports(exportsField)).toEqual(['fs', 'mcp-response'])
+	})
+})
+
+describe('cleanSignature', () => {
+	it('removes declare prefix and trailing semicolon', () => {
+		expect(cleanSignature('declare function foo(): void;')).toBe('function foo(): void')
+	})
+
+	it('truncates signatures >200 chars at params', () => {
+		const longSig = `declare function veryLongFunction(${Array(20).fill('paramName: SomeLongGenericType<Another>').join(', ')}): Promise<void>;`
+		const result = cleanSignature(longSig)
+		expect(result.length).toBeLessThanOrEqual(200)
+		expect(result).toContain('(...)')
+	})
+})
+
+describe('validateFunctionJsdoc', () => {
+	it('reports error for function with no JSDoc', () => {
+		const dts = `declare function orphan(): void;`
+		const errors = validateFunctionJsdoc(dts, 'test.d.ts', 'test')
+		expect(errors).toHaveLength(1)
+		expect(errors[0]?.name).toBe('orphan')
+	})
+
+	it('reports error for function with trivial JSDoc', () => {
+		const dts = `/**
+* TODO
+*/
+declare function incomplete(): void;`
+		const errors = validateFunctionJsdoc(dts, 'test.d.ts', 'test')
+		expect(errors).toHaveLength(1)
+	})
+
+	it('allows const/class/enum without JSDoc', () => {
+		const dts = `declare const VALUE = "x";
+declare class Thing {}
+declare enum Mode { A = "a" }`
+		const errors = validateFunctionJsdoc(dts, 'test.d.ts', 'test')
+		expect(errors).toHaveLength(0)
+	})
+
+	it('skips @catalog-skip declarations', () => {
+		const dts = `/** @catalog-skip */
+declare function hidden(): void;`
+		const errors = validateFunctionJsdoc(dts, 'test.d.ts', 'test')
+		expect(errors).toHaveLength(0)
+	})
+
+	it('passes for function with adequate JSDoc', () => {
+		const dts = `/**
+* Format a color as ANSI escape code for terminal output.
+*/
+declare function color(input: string): string;`
+		const errors = validateFunctionJsdoc(dts, 'test.d.ts', 'test')
+		expect(errors).toHaveLength(0)
+	})
+
+	it('validates only exported local function names when provided', () => {
+		const dts = `declare function internalOnly(): void;
+/**
+* Public function with docs.
+*/
+declare function publicFn(): void;`
+
+		const errors = validateFunctionJsdoc(dts, 'test.d.ts', 'test', new Set(['publicFn']))
+		expect(errors).toHaveLength(0)
+	})
+})
+
+describe('catalog module wrapper generation', () => {
+	it('generates JS wrapper that reads catalog.json', () => {
+		const js = generateCatalogModuleJs()
+		expect(js).toContain("readFileSync(new URL('./catalog.json', import.meta.url)")
+		expect(js).toContain('export default catalog')
+	})
+
+	it('generates d.ts wrapper typings', () => {
+		const dts = generateCatalogModuleDts()
+		expect(dts).toContain('export interface CoreApiCatalog')
+		expect(dts).toContain('declare const catalog: CoreApiCatalog')
+	})
+})
+
+describe('generateLlmsTxt', () => {
+	const mockCatalog: Catalog = {
+		schemaVersion: 1,
+		packageVersion: '0.2.0',
+		generated: '2026-02-09T00:00:00.000Z',
+		moduleCount: 2,
+		declarationCount: 5,
+		modules: {
+			concurrency: {
+				summary: 'Concurrency utilities for safe concurrent operations',
+				exports: ['withFileLock', 'Transaction'],
+				declarations: [],
+			},
+			fs: {
+				summary: 'Bun-native filesystem operations',
+				exports: ['readFile', 'writeFile'],
+				declarations: [],
+			},
+		},
+	}
+
+	it('produces valid llms.txt format with H1 and blockquote', () => {
+		const result = generateLlmsTxt(mockCatalog, '@side-quest/core')
+		expect(result).toContain('# @side-quest/core')
+		expect(result).toContain('> 2 modules')
+	})
+
+	it('includes GitHub source links for each module', () => {
+		const result = generateLlmsTxt(mockCatalog, '@side-quest/core')
+		expect(result).toContain(
+			'[concurrency](https://github.com/nathanvale/side-quest-core/tree/main/src/concurrency)',
+		)
+		expect(result).toContain('[fs](https://github.com/nathanvale/side-quest-core/tree/main/src/fs)')
+	})
+
+	it('includes link to catalog.json in Optional section', () => {
+		const result = generateLlmsTxt(mockCatalog, '@side-quest/core')
+		expect(result).toContain('## Optional')
+		expect(result).toContain('./catalog.json')
+	})
+
+	it('sorts modules alphabetically', () => {
+		const result = generateLlmsTxt(mockCatalog, '@side-quest/core')
+		const concurrencyIdx = result.indexOf('concurrency')
+		const fsIdx = result.indexOf('[fs]')
+		expect(concurrencyIdx).toBeLessThan(fsIdx)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Integration test (requires dist/ from a prior build)
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!existsSync('dist/src'))('integration', () => {
+	it('generates catalog from real dist/ files', async () => {
+		const catalog = await generateCatalog()
+		const pkg = JSON.parse(readFileSync('package.json', 'utf-8')) as {
+			exports?: unknown
+		}
+		const expectedModules = getExpectedModuleNamesFromPackageExports(pkg.exports)
+
+		expect(catalog.moduleCount).toBe(expectedModules.length)
+		expect(catalog.declarationCount).toBeGreaterThan(50)
+		expect(Object.keys(catalog.modules).sort()).toEqual(expectedModules)
+
+		// Spot-check known exports
+		expect(catalog.modules.concurrency?.exports).toContain('withFileLock')
+		expect(catalog.modules.concurrency?.exports).toContain('Transaction')
+		expect(catalog.modules.terminal?.exports).toContain('color')
+		expect(catalog.modules.mcp?.exports).toContain('tool')
+		expect(catalog.modules.mcp?.exports).toContain('startServer')
+
+		// Re-export + alias correctness checks
+		expect(catalog.modules.git?.exports).toContain('unescapeGitPath')
+		expect(catalog.modules.git?.exports).not.toContain('unescapeGitPath2')
+		expect(catalog.modules.mcp?.exports).toContain('z')
+		expect(catalog.modules.fs?.exports).toContain('readFileSync')
+
+		// Wrapper artifacts exist and are importable
+		expect(existsSync('dist/catalog.js')).toBe(true)
+		expect(existsSync('dist/catalog.d.ts')).toBe(true)
+
+		const { pathToFileURL } = await import('node:url')
+		const { resolve: resolvePath } = await import('node:path')
+		const wrapperUrl = pathToFileURL(resolvePath('dist/catalog.js')).href
+		const wrapperModule = (await import(wrapperUrl)) as {
+			default: { moduleCount: number; declarationCount: number }
+		}
+		expect(wrapperModule.default.moduleCount).toBe(catalog.moduleCount)
+		expect(wrapperModule.default.declarationCount).toBe(catalog.declarationCount)
+
+		const catalogDts = readFileSync('dist/catalog.d.ts', 'utf-8')
+		expect(catalogDts).toContain('export interface CoreApiCatalog')
+	})
+})

--- a/scripts/generate-catalog.ts
+++ b/scripts/generate-catalog.ts
@@ -1,0 +1,937 @@
+#!/usr/bin/env bun
+/**
+ * Generate API catalog from built .d.ts files and source barrel modules.
+ *
+ * Produces four artifacts:
+ * - dist/catalog.json  -- structured JSON for programmatic consumption
+ * - dist/catalog.js    -- runtime wrapper for Node/Bun subpath import
+ * - dist/catalog.d.ts  -- types for the catalog wrapper
+ * - dist/llms.txt      -- llms.txt community standard for ecosystem tools
+ *
+ * Runs as a postbuild step after `bunx bunup`.
+ *
+ * @example
+ * ```bash
+ * bun scripts/generate-catalog.ts
+ * ```
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { isMainScript } from '../src/terminal/index.ts'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A single runtime declaration extracted from a .d.ts file */
+export interface Declaration {
+	name: string
+	kind: 'function' | 'class' | 'enum' | 'const'
+	signature: string
+	description: string
+}
+
+/** A runtime export binding from generated JS (local -> exported) */
+export interface ExportBinding {
+	local: string
+	exported: string
+}
+
+/** A module entry in the catalog */
+export interface ModuleEntry {
+	summary: string
+	exports: string[]
+	declarations: Declaration[]
+}
+
+/** The full catalog structure */
+export interface Catalog {
+	schemaVersion: number
+	packageVersion: string
+	generated: string
+	moduleCount: number
+	declarationCount: number
+	modules: Record<string, ModuleEntry>
+}
+
+/** Validation error for missing JSDoc */
+export interface JsdocError {
+	file: string
+	line: number
+	name: string
+	signature: string
+	sourceHint: string
+}
+
+// ---------------------------------------------------------------------------
+// Module summary extraction (from source barrel files)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the first descriptive line from a module's top-level JSDoc block.
+ *
+ * Reads `src/{module}/index.ts` and finds the opening `/** ... * /` block.
+ * Skips `@module`, `@packageDocumentation`, `@example` tags, and code fences.
+ * Returns the first line that looks like a real English sentence.
+ *
+ * @param sourceContent - Content of the source barrel file
+ * @returns First descriptive line, or empty string if none found
+ */
+export function extractModuleSummary(sourceContent: string): string {
+	// Find the first JSDoc block at the top of the file
+	const jsdocMatch = sourceContent.match(/^\s*\/\*\*([\s\S]*?)\*\//)
+	if (!jsdocMatch) return ''
+
+	const block = jsdocMatch[1] as string
+	const lines = block.split('\n')
+
+	let inCodeFence = false
+
+	for (const raw of lines) {
+		const line = raw.replace(/^\s*\*\s?/, '').trim()
+
+		// Track code fences
+		if (line.startsWith('```')) {
+			inCodeFence = !inCodeFence
+			continue
+		}
+		if (inCodeFence) continue
+
+		// Skip tags
+		if (line.startsWith('@module')) continue
+		if (line.startsWith('@packageDocumentation')) continue
+		if (line.startsWith('@example')) continue
+		if (line.startsWith('@')) continue
+
+		// Skip empty lines
+		if (line.length === 0) continue
+
+		// Skip headings (## Key Features, etc.)
+		if (line.startsWith('#')) continue
+
+		// Skip list items that look like feature lists
+		if (line.startsWith('- **')) continue
+
+		// Must look like a real sentence (>10 chars, starts with a letter)
+		if (line.length > 10 && /^[A-Z]/.test(line)) {
+			return line
+		}
+	}
+
+	return ''
+}
+
+// ---------------------------------------------------------------------------
+// Declaration parsing (from .d.ts files)
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a JSDoc block contains @catalog-skip.
+ *
+ * @param jsdocBlock - Raw JSDoc text including delimiters
+ * @returns True if @catalog-skip is present
+ */
+export function hasCatalogSkip(jsdocBlock: string): boolean {
+	return /@catalog-skip/.test(jsdocBlock)
+}
+
+/**
+ * Extract JSDoc description by walking backwards from a declaration line.
+ *
+ * Skips `@param`, `@returns`, `@example`, `@catalog-skip` tags,
+ * code fence content, and lines that look like code examples.
+ * Returns the first line that looks like a real English sentence.
+ *
+ * @param lines - All lines from the .d.ts file
+ * @param declLineIndex - Index of the declaration line
+ * @returns Description string, or empty string if none found
+ */
+export function getJsdocDescription(
+	lines: string[],
+	declLineIndex: number,
+): string {
+	// Walk backwards to find the closing */ of a JSDoc block
+	let endIdx = -1
+	for (let i = declLineIndex - 1; i >= 0; i--) {
+		const trimmed = (lines[i] as string).trim()
+		if (trimmed === '') continue
+		if (trimmed.endsWith('*/')) {
+			endIdx = i
+			break
+		}
+		// If we hit something that isn't whitespace or JSDoc close, no JSDoc
+		break
+	}
+
+	if (endIdx === -1) return ''
+
+	// Walk backwards to find the opening /**
+	let startIdx = -1
+	for (let i = endIdx; i >= 0; i--) {
+		if ((lines[i] as string).trim().startsWith('/**')) {
+			startIdx = i
+			break
+		}
+	}
+
+	if (startIdx === -1) return ''
+
+	// Parse the JSDoc block
+	const jsdocLines = lines.slice(startIdx, endIdx + 1)
+	const candidates: string[] = []
+	let inCodeFence = false
+
+	for (const raw of jsdocLines) {
+		const line = raw
+			.replace(/^\s*\/?\*+\s?/, '')
+			.replace(/\*\/\s*$/, '')
+			.trim()
+
+		// Track code fences
+		if (line.startsWith('```')) {
+			inCodeFence = !inCodeFence
+			continue
+		}
+		if (inCodeFence) continue
+
+		// Skip tags
+		if (line.startsWith('@param')) continue
+		if (line.startsWith('@returns')) continue
+		if (line.startsWith('@example')) continue
+		if (line.startsWith('@catalog-skip')) continue
+		if (line.startsWith('@template')) continue
+		if (line.startsWith('@throws')) continue
+		if (line.startsWith('@default')) continue
+		if (line.startsWith('@module')) continue
+		if (line.startsWith('@')) continue
+
+		// Skip empty
+		if (line.length === 0) continue
+
+		// Skip lines that look like code examples
+		if (/^(const |let |var |await |import |console\.|\/\/)/.test(line)) continue
+
+		// Skip headings
+		if (line.startsWith('#')) continue
+
+		// Skip list items with bold labels (feature lists)
+		if (line.startsWith('- **')) continue
+
+		// Collect candidate description lines (>10 chars, starts with letter)
+		if (line.length > 10 && /^[A-Za-z]/.test(line)) {
+			candidates.push(line)
+		}
+	}
+
+	// Return first candidate
+	return candidates[0] ?? ''
+}
+
+/**
+ * Get the full JSDoc block text preceding a declaration line.
+ *
+ * @param lines - All lines from the .d.ts file
+ * @param declLineIndex - Index of the declaration line
+ * @returns Full JSDoc block text, or empty string if none found
+ */
+export function getJsdocBlock(lines: string[], declLineIndex: number): string {
+	// Walk backwards to find the closing */
+	let endIdx = -1
+	for (let i = declLineIndex - 1; i >= 0; i--) {
+		const trimmed = (lines[i] as string).trim()
+		if (trimmed === '') continue
+		if (trimmed.endsWith('*/')) {
+			endIdx = i
+			break
+		}
+		break
+	}
+
+	if (endIdx === -1) return ''
+
+	// Walk backwards to find the opening /**
+	let startIdx = -1
+	for (let i = endIdx; i >= 0; i--) {
+		if ((lines[i] as string).trim().startsWith('/**')) {
+			startIdx = i
+			break
+		}
+	}
+
+	if (startIdx === -1) return ''
+
+	return lines.slice(startIdx, endIdx + 1).join('\n')
+}
+
+/**
+ * Clean a declaration signature for catalog output.
+ *
+ * - Removes `declare ` prefix
+ * - Collapses multi-line generic signatures onto one line
+ * - Truncates signatures >200 chars at the params
+ *
+ * @param signature - Raw declaration signature (may be multi-line)
+ * @returns Cleaned signature string
+ */
+export function cleanSignature(signature: string): string {
+	// Remove declare prefix
+	let sig = signature.replace(/^declare\s+/, '')
+
+	// Collapse to one line
+	sig = sig
+		.replace(/\s*\n\s*/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim()
+
+	// Remove trailing semicolon
+	sig = sig.replace(/;$/, '')
+
+	// Truncate if >200 chars
+	if (sig.length > 200) {
+		// Try to truncate at the params for functions
+		const parenIdx = sig.indexOf('(')
+		if (parenIdx !== -1) {
+			// Find return type
+			const colonAfterParen = sig.lastIndexOf('): ')
+			if (colonAfterParen !== -1) {
+				const returnType = sig.slice(colonAfterParen + 2).trim()
+				const name = sig.slice(0, parenIdx)
+				sig = `${name}(...): ${returnType}`
+			} else {
+				sig = `${sig.slice(0, parenIdx)}(...)`
+			}
+		} else {
+			sig = `${sig.slice(0, 197)}...`
+		}
+	}
+
+	return sig
+}
+
+/**
+ * Parse runtime declarations from a .d.ts file's content.
+ *
+ * Finds all `declare function|class|enum|const` lines (runtime exports only).
+ * Skips `type` and `interface` declarations.
+ * Deduplicates by name (handles function overloads).
+ * Handles multi-line `declare const` with object types using brace counting.
+ * Skips declarations tagged with `@catalog-skip`.
+ *
+ * @param dtsContent - Content of a .d.ts file
+ * @returns Array of parsed declarations
+ */
+export function parseDeclarations(dtsContent: string): Declaration[] {
+	const lines = dtsContent.split('\n')
+	const declarations: Declaration[] = []
+	const seenNames = new Set<string>()
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = (lines[i] as string).trim()
+
+		// Match declare function/class/enum/const
+		const match = line.match(/^declare\s+(function|class|enum|const)\s+(\w+)/)
+		if (!match) continue
+
+		const kind = match[1] as Declaration['kind']
+		const name = match[2] as string
+
+		// Deduplicate (function overloads)
+		if (seenNames.has(name)) continue
+
+		// Check for @catalog-skip in preceding JSDoc
+		const jsdocBlock = getJsdocBlock(lines, i)
+		if (jsdocBlock && hasCatalogSkip(jsdocBlock)) continue
+
+		// Build the full signature
+		let signature = line
+
+		if (kind === 'const') {
+			// Handle multi-line const with object types (brace counting)
+			let braceCount = 0
+			let foundBrace = false
+
+			for (let j = 0; j < signature.length; j++) {
+				if (signature[j] === '{') {
+					braceCount++
+					foundBrace = true
+				}
+				if (signature[j] === '}') braceCount--
+			}
+
+			if (foundBrace && braceCount > 0) {
+				// Multi-line - read until braces balance
+				let fullSig = line
+				let lineIdx = i + 1
+				while (braceCount > 0 && lineIdx < lines.length) {
+					const nextLine = lines[lineIdx] as string
+					fullSig += ` ${nextLine.trim()}`
+					for (let j = 0; j < nextLine.length; j++) {
+						if (nextLine[j] === '{') braceCount++
+						if (nextLine[j] === '}') braceCount--
+					}
+					lineIdx++
+				}
+
+				// Truncate object type to `const NAME: { ... }`
+				const colonIdx = line.indexOf(':')
+				if (colonIdx !== -1) {
+					signature = `${line.slice(0, colonIdx)}: { ... }`
+				} else {
+					signature = fullSig
+				}
+			}
+		} else if (kind === 'function') {
+			// Check if function signature spans multiple lines (unclosed parens)
+			let parenCount = 0
+			for (let j = 0; j < signature.length; j++) {
+				if (signature[j] === '(') parenCount++
+				if (signature[j] === ')') parenCount--
+			}
+
+			if (parenCount > 0) {
+				let fullSig = line
+				let lineIdx = i + 1
+				while (parenCount > 0 && lineIdx < lines.length) {
+					const nextLine = (lines[lineIdx] as string).trim()
+					fullSig += ` ${nextLine}`
+					for (let j = 0; j < nextLine.length; j++) {
+						if (nextLine[j] === '(') parenCount++
+						if (nextLine[j] === ')') parenCount--
+					}
+					lineIdx++
+				}
+				// May need to grab the return type on the next line
+				if (lineIdx < lines.length) {
+					const nextLine = (lines[lineIdx] as string).trim()
+					if (nextLine.startsWith(':')) {
+						fullSig += ` ${nextLine}`
+					}
+				}
+				signature = fullSig
+			}
+		} else if (kind === 'class') {
+			// For classes, just take the first line (class NAME { ... })
+			// We don't need the full class body
+			const braceIdx = line.indexOf('{')
+			if (braceIdx !== -1) {
+				signature = line.slice(0, braceIdx).trim()
+			}
+			// If extends or implements across lines, grab those
+			if (!line.includes('{') && !line.endsWith(';')) {
+				let fullSig = line
+				let lineIdx = i + 1
+				while (lineIdx < lines.length) {
+					const nextLine = (lines[lineIdx] as string).trim()
+					if (nextLine.startsWith('{') || nextLine === '') break
+					fullSig += ` ${nextLine}`
+					lineIdx++
+				}
+				signature = fullSig
+			}
+		}
+
+		const description = getJsdocDescription(lines, i)
+		const cleaned = cleanSignature(signature)
+
+		seenNames.add(name)
+		declarations.push({
+			name,
+			kind,
+			signature: cleaned,
+			description,
+		})
+	}
+
+	return declarations
+}
+
+/**
+ * Parse runtime export bindings from generated JavaScript.
+ *
+ * Supports export lists such as:
+ * `export { a, b as c }`
+ *
+ * @param jsContent - Content of generated module JS
+ * @returns Export bindings in declaration order
+ */
+export function parseJsExportBindings(jsContent: string): ExportBinding[] {
+	const bindings: ExportBinding[] = []
+	const exportListRegex = /export\s*\{([\s\S]*?)\};?/g
+
+	for (const match of jsContent.matchAll(exportListRegex)) {
+		const body = match[1] ?? ''
+		for (const rawPart of body.split(',')) {
+			const part = rawPart.trim()
+			if (!part || part === 'default') continue
+
+			if (part.includes(' as ')) {
+				const [local, exported] = part.split(/\s+as\s+/)
+				if (!local || !exported) continue
+				bindings.push({ local: local.trim(), exported: exported.trim() })
+				continue
+			}
+
+			bindings.push({ local: part, exported: part })
+		}
+	}
+
+	return bindings
+}
+
+/**
+ * Collect declaration names marked with @catalog-skip in .d.ts JSDoc blocks.
+ *
+ * @param dtsContent - Content of a .d.ts file
+ * @returns Set of local declaration names to exclude from catalog exports
+ */
+export function getCatalogSkipDeclarationNames(
+	dtsContent: string,
+): Set<string> {
+	const lines = dtsContent.split('\n')
+	const skippedNames = new Set<string>()
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = (lines[i] as string).trim()
+		const match = line.match(/^declare\s+(function|class|enum|const)\s+(\w+)/)
+		if (!match) continue
+
+		const name = match[2] as string
+		const jsdocBlock = getJsdocBlock(lines, i)
+		if (jsdocBlock && hasCatalogSkip(jsdocBlock)) {
+			skippedNames.add(name)
+		}
+	}
+
+	return skippedNames
+}
+
+/**
+ * Derive expected module names from package.json exports by structure.
+ *
+ * A module export is any subpath whose `import` target matches:
+ * `./dist/src/{module}/index.js`
+ *
+ * @param exportsField - package.json exports value
+ * @returns Sorted unique list of expected module names
+ */
+export function getExpectedModuleNamesFromPackageExports(
+	exportsField: unknown,
+): string[] {
+	if (!exportsField || typeof exportsField !== 'object') return []
+
+	const modules = new Set<string>()
+
+	for (const value of Object.values(exportsField as Record<string, unknown>)) {
+		if (!value || typeof value !== 'object') continue
+		const importPath = (value as Record<string, unknown>).import
+		if (typeof importPath !== 'string') continue
+
+		const match = importPath.match(/^\.\/dist\/src\/([^/]+)\/index\.js$/)
+		if (!match) continue
+		modules.add(match[1] as string)
+	}
+
+	return Array.from(modules).sort()
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate that all exported functions have JSDoc with non-trivial descriptions.
+ *
+ * - `declare function` without JSDoc: error
+ * - `declare function` with trivial JSDoc (<=10 chars or only whitespace/tags): error
+ * - `declare const/class/enum` without JSDoc: allowed
+ * - Declarations with @catalog-skip: excluded from validation
+ *
+ * @param dtsContent - Content of a .d.ts file
+ * @param filePath - Path to the .d.ts file (for error messages)
+ * @param moduleName - Module name (for source hint)
+ * @param exportedLocalFunctionNames - Optional set of local function names that
+ * are actually exported at runtime for this module
+ * @returns Array of validation errors
+ */
+export function validateFunctionJsdoc(
+	dtsContent: string,
+	filePath: string,
+	moduleName: string,
+	exportedLocalFunctionNames?: ReadonlySet<string>,
+): JsdocError[] {
+	const lines = dtsContent.split('\n')
+	const errors: JsdocError[] = []
+	const seenNames = new Set<string>()
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = (lines[i] as string).trim()
+
+		const match = line.match(/^declare\s+function\s+(\w+)/)
+		if (!match) continue
+
+		const name = match[1] as string
+
+		// Only validate functions that are runtime-exported from this module
+		if (exportedLocalFunctionNames && !exportedLocalFunctionNames.has(name)) {
+			continue
+		}
+
+		// Skip overloads (only validate first occurrence)
+		if (seenNames.has(name)) continue
+		seenNames.add(name)
+
+		// Skip @catalog-skip
+		const jsdocBlock = getJsdocBlock(lines, i)
+		if (jsdocBlock && hasCatalogSkip(jsdocBlock)) continue
+
+		// Check for JSDoc presence
+		const description = getJsdocDescription(lines, i)
+		if (!jsdocBlock || description.length <= 10) {
+			// Build signature for error output
+			const signature = cleanSignature(line)
+			errors.push({
+				file: filePath,
+				line: i + 1,
+				name,
+				signature,
+				sourceHint: `src/${moduleName}/index.ts`,
+			})
+		}
+	}
+
+	return errors
+}
+
+// ---------------------------------------------------------------------------
+// llms.txt generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate llms.txt content following the llms.txt community standard.
+ *
+ * @param catalog - The generated catalog data
+ * @param packageName - npm package name
+ * @returns llms.txt content string
+ */
+export function generateLlmsTxt(catalog: Catalog, packageName: string): string {
+	const moduleNames = Object.keys(catalog.modules).sort()
+	const repoUrl = 'https://github.com/nathanvale/side-quest-core'
+
+	const lines: string[] = [
+		`# ${packageName}`,
+		'',
+		`> ${catalog.moduleCount} modules of reusable TypeScript utilities for Bun -- filesystem, MCP, concurrency, hashing, spawn, and more. Runtime exports only.`,
+		'',
+		`- [${packageName} on npm](https://www.npmjs.com/package/${packageName})`,
+		`- [Source code](${repoUrl})`,
+		'',
+		'## Modules',
+		'',
+	]
+
+	for (const name of moduleNames) {
+		const mod = catalog.modules[name] as ModuleEntry
+		const summary = mod.summary || `${name} module`
+		lines.push(`- [${name}](${repoUrl}/tree/main/src/${name}): ${summary}`)
+	}
+
+	lines.push('')
+	lines.push('## Optional')
+	lines.push('')
+	lines.push(
+		'- [Full API catalog (JSON)](./catalog.json): Structured JSON with all type signatures, descriptions, and export names',
+	)
+	lines.push('')
+
+	return lines.join('\n')
+}
+
+/**
+ * Generate JavaScript wrapper content for `@side-quest/core/catalog`.
+ *
+ * Why: Node.js ESM requires import attributes for direct JSON imports.
+ * This wrapper provides stable runtime loading for both Bun and Node.
+ *
+ * @returns JavaScript module source
+ */
+export function generateCatalogModuleJs(): string {
+	return `import { readFileSync } from 'node:fs'
+
+const catalog = JSON.parse(
+  readFileSync(new URL('./catalog.json', import.meta.url), 'utf-8'),
+)
+
+export default catalog
+`
+}
+
+/**
+ * Generate TypeScript declaration content for `dist/catalog.js`.
+ *
+ * @returns .d.ts module source
+ */
+export function generateCatalogModuleDts(): string {
+	return `export interface CatalogDeclaration {
+  name: string
+  kind: 'function' | 'class' | 'enum' | 'const'
+  signature: string
+  description: string
+}
+
+export interface CatalogModuleEntry {
+  summary: string
+  exports: string[]
+  declarations: CatalogDeclaration[]
+}
+
+export interface CoreApiCatalog {
+  schemaVersion: number
+  packageVersion: string
+  generated: string
+  moduleCount: number
+  declarationCount: number
+  modules: Record<string, CatalogModuleEntry>
+}
+
+declare const catalog: CoreApiCatalog
+export default catalog
+`
+}
+
+// ---------------------------------------------------------------------------
+// Main script
+// ---------------------------------------------------------------------------
+
+/**
+ * Main catalog generation logic.
+ *
+ * @returns The generated catalog object
+ * @throws Error if validation fails
+ */
+export async function generateCatalog(): Promise<Catalog> {
+	const rootDir = resolve(import.meta.dir, '..')
+	const distDir = join(rootDir, 'dist')
+	const srcDir = join(rootDir, 'src')
+
+	// Check dist exists
+	if (!existsSync(distDir)) {
+		throw new Error('dist/ directory not found. Run `bun run build` first.')
+	}
+
+	// Read package.json
+	const pkgPath = join(rootDir, 'package.json')
+	const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
+	const packageVersion: string = pkg.version
+	const packageName: string = pkg.name
+
+	// Derive expected module names from package.json exports structure
+	const expectedModuleNames = getExpectedModuleNamesFromPackageExports(
+		pkg.exports,
+	)
+	if (expectedModuleNames.length === 0) {
+		throw new Error(
+			'No module exports found in package.json (expected ./dist/src/*/index.js import targets).',
+		)
+	}
+
+	// Discover modules from dist/src/*/index.d.ts
+	const distSrcDir = join(distDir, 'src')
+	if (!existsSync(distSrcDir)) {
+		throw new Error('dist/src/ directory not found. Build may have failed.')
+	}
+
+	const discoveredModuleDirs = readdirSync(distSrcDir)
+		.filter((name) => {
+			const dtsPath = join(distSrcDir, name, 'index.d.ts')
+			return existsSync(dtsPath)
+		})
+		.sort()
+
+	const missingExpectedModules = expectedModuleNames.filter(
+		(name) => !discoveredModuleDirs.includes(name),
+	)
+	if (missingExpectedModules.length > 0) {
+		throw new Error(
+			`Missing built module(s) declared in package exports: ${missingExpectedModules.join(', ')}\nBuilt modules found: ${discoveredModuleDirs.join(', ')}`,
+		)
+	}
+
+	// Catalog only package-exported modules to avoid accidental dist/src noise.
+	const moduleDirs = expectedModuleNames
+	const ignoredDiscoveredModules = discoveredModuleDirs.filter(
+		(name) => !expectedModuleNames.includes(name),
+	)
+	if (ignoredDiscoveredModules.length > 0) {
+		console.warn(
+			`WARNING: Ignoring non-exported built module(s): ${ignoredDiscoveredModules.join(', ')}`,
+		)
+	}
+
+	const modules: Record<string, ModuleEntry> = {}
+	const allJsdocErrors: JsdocError[] = []
+	const missingSummaryModules: string[] = []
+	let totalDeclarations = 0
+
+	for (const moduleName of moduleDirs) {
+		// Read module summary from source
+		const srcBarrelPath = join(srcDir, moduleName, 'index.ts')
+		let summary = ''
+		if (existsSync(srcBarrelPath)) {
+			const srcContent = readFileSync(srcBarrelPath, 'utf-8')
+			summary = extractModuleSummary(srcContent)
+			if (!summary) {
+				missingSummaryModules.push(moduleName)
+			}
+		} else {
+			missingSummaryModules.push(moduleName)
+		}
+
+		// Parse declarations from .d.ts
+		const dtsPath = join(distSrcDir, moduleName, 'index.d.ts')
+		const dtsContent = readFileSync(dtsPath, 'utf-8')
+		const declarations = parseDeclarations(dtsContent)
+		const declarationByLocalName = new Map(
+			declarations.map((declaration) => [declaration.name, declaration]),
+		)
+		const skippedLocalNames = getCatalogSkipDeclarationNames(dtsContent)
+
+		// Parse runtime export names from generated JS so aliases/re-exports stay accurate
+		const jsPath = join(distSrcDir, moduleName, 'index.js')
+		const jsContent = readFileSync(jsPath, 'utf-8')
+		const exportBindings = parseJsExportBindings(jsContent)
+		const exportedLocalFunctionNames =
+			exportBindings.length > 0
+				? new Set(
+						exportBindings
+							.map((binding) => binding.local)
+							.filter((name) => !skippedLocalNames.has(name)),
+					)
+				: undefined
+
+		// Validate function JSDoc
+		const errors = validateFunctionJsdoc(
+			dtsContent,
+			dtsPath,
+			moduleName,
+			exportedLocalFunctionNames,
+		)
+		allJsdocErrors.push(...errors)
+
+		const exportNames: string[] = []
+		const mappedDeclarations: Declaration[] = []
+		const seenExportNames = new Set<string>()
+
+		for (const binding of exportBindings) {
+			if (skippedLocalNames.has(binding.local)) continue
+			if (seenExportNames.has(binding.exported)) continue
+			seenExportNames.add(binding.exported)
+			exportNames.push(binding.exported)
+
+			const declaration = declarationByLocalName.get(binding.local)
+			if (!declaration) continue
+			mappedDeclarations.push({
+				...declaration,
+				name: binding.exported,
+			})
+		}
+
+		// Fallback for unexpected JS emit changes
+		if (exportBindings.length === 0) {
+			for (const declaration of declarations) {
+				exportNames.push(declaration.name)
+				mappedDeclarations.push(declaration)
+			}
+		}
+
+		totalDeclarations += mappedDeclarations.length
+
+		modules[moduleName] = {
+			summary,
+			exports: exportNames,
+			declarations: mappedDeclarations,
+		}
+	}
+
+	// Report missing module summaries
+	if (missingSummaryModules.length > 0) {
+		const files = missingSummaryModules
+			.map((mod) => `  src/${mod}/index.ts`)
+			.join('\n')
+		throw new Error(
+			`Missing top-level JSDoc summary in ${missingSummaryModules.length} module(s):\n${files}\n\nAdd a /** ... */ JSDoc block at the top of each barrel file.`,
+		)
+	}
+
+	// Report JSDoc errors
+	if (allJsdocErrors.length > 0) {
+		const details = allJsdocErrors
+			.map(
+				(err) =>
+					`  ${err.file}:${err.line}\n  ${err.signature}\n  -> Fix in: ${err.sourceHint}`,
+			)
+			.join('\n\n')
+		throw new Error(
+			`Missing JSDoc for ${allJsdocErrors.length} exported function(s)\n\n${details}\n\nAdd /** ... */ blocks above these functions, then re-run: bun run build`,
+		)
+	}
+
+	const catalog: Catalog = {
+		schemaVersion: 1,
+		packageVersion,
+		generated: new Date().toISOString(),
+		moduleCount: moduleDirs.length,
+		declarationCount: totalDeclarations,
+		modules,
+	}
+
+	// Write catalog.json
+	const catalogJson = JSON.stringify(catalog, null, 2)
+	const catalogPath = join(distDir, 'catalog.json')
+	await Bun.write(catalogPath, catalogJson)
+
+	// Write catalog module wrapper + types
+	const catalogModuleJsPath = join(distDir, 'catalog.js')
+	await Bun.write(catalogModuleJsPath, generateCatalogModuleJs())
+	const catalogModuleDtsPath = join(distDir, 'catalog.d.ts')
+	await Bun.write(catalogModuleDtsPath, generateCatalogModuleDts())
+
+	// Write llms.txt
+	const llmsTxt = generateLlmsTxt(catalog, packageName)
+	const llmsTxtPath = join(distDir, 'llms.txt')
+	await Bun.write(llmsTxtPath, llmsTxt)
+
+	// Print success summary
+	const catalogSize = statSync(catalogPath).size
+	const catalogModuleJsSize = statSync(catalogModuleJsPath).size
+	const catalogModuleDtsSize = statSync(catalogModuleDtsPath).size
+	const llmsSize = statSync(llmsTxtPath).size
+	const formatSize = (bytes: number) => {
+		if (bytes < 1024) return `${bytes} B`
+		return `${(bytes / 1024).toFixed(1)} KB`
+	}
+
+	console.log(
+		`Catalog generated: ${moduleDirs.length} modules, ${totalDeclarations} declarations`,
+	)
+	console.log('All exported functions documented')
+	console.log(`dist/catalog.json (${formatSize(catalogSize)})`)
+	console.log(`dist/catalog.js (${formatSize(catalogModuleJsSize)})`)
+	console.log(`dist/catalog.d.ts (${formatSize(catalogModuleDtsSize)})`)
+	console.log(`dist/llms.txt (${formatSize(llmsSize)})`)
+
+	return catalog
+}
+
+// ---------------------------------------------------------------------------
+// Entry point guard
+// ---------------------------------------------------------------------------
+
+if (isMainScript(import.meta.path)) {
+	try {
+		await generateCatalog()
+	} catch (err) {
+		console.error(err instanceof Error ? err.message : err)
+		process.exit(1)
+	}
+}

--- a/src/formatters/index.ts
+++ b/src/formatters/index.ts
@@ -54,8 +54,7 @@ export {
 	formatTime12Hour,
 } from './time.ts'
 
-// Legacy colors object for existing code that uses colors.red, colors.green, etc.
-// This provides the raw ANSI codes that were previously exported
+/** @catalog-skip Legacy ANSI color codes object */
 export const colors = {
 	reset: '\x1b[0m',
 	dim: '\x1b[2m',

--- a/src/terminal/index.ts
+++ b/src/terminal/index.ts
@@ -91,20 +91,28 @@ export function bgColor(input: ColorInput, text?: string): string {
 	return bg
 }
 
-/** ANSI reset code */
+/** @catalog-skip ANSI reset code */
 export const RESET = '\x1b[0m'
 
-/** ANSI style codes */
+/** @catalog-skip ANSI style codes */
 export const BOLD = '\x1b[1m'
+/** @catalog-skip */
 export const DIM = '\x1b[2m'
+/** @catalog-skip */
 export const ITALIC = '\x1b[3m'
+/** @catalog-skip */
 export const UNDERLINE = '\x1b[4m'
+/** @catalog-skip */
 export const BLINK = '\x1b[5m'
+/** @catalog-skip */
 export const INVERSE = '\x1b[7m'
+/** @catalog-skip */
 export const HIDDEN = '\x1b[8m'
+/** @catalog-skip */
 export const STRIKETHROUGH = '\x1b[9m'
 
 /**
+ * @catalog-skip - Use color() for programmatic styling
  * Apply bold style to text
  */
 export function bold(text: string): string {
@@ -112,6 +120,7 @@ export function bold(text: string): string {
 }
 
 /**
+ * @catalog-skip - Use color() for programmatic styling
  * Apply dim style to text
  */
 export function dim(text: string): string {
@@ -119,6 +128,7 @@ export function dim(text: string): string {
 }
 
 /**
+ * @catalog-skip - Use color() for programmatic styling
  * Apply italic style to text
  */
 export function italic(text: string): string {
@@ -126,6 +136,7 @@ export function italic(text: string): string {
 }
 
 /**
+ * @catalog-skip - Use color() for programmatic styling
  * Apply underline style to text
  */
 export function underline(text: string): string {
@@ -133,6 +144,7 @@ export function underline(text: string): string {
 }
 
 /**
+ * @catalog-skip - Use color() for programmatic styling
  * Apply strikethrough style to text
  */
 export function strikethrough(text: string): string {
@@ -140,6 +152,7 @@ export function strikethrough(text: string): string {
 }
 
 /**
+ * @catalog-skip - Use color() for programmatic styling
  * Apply inverse (swap foreground/background) style
  */
 export function inverse(text: string): string {
@@ -151,6 +164,7 @@ export function inverse(text: string): string {
 // ============================================================================
 
 /**
+ * @catalog-skip - Use color() instead
  * Red text for errors
  */
 export function red(text: string): string {
@@ -158,6 +172,7 @@ export function red(text: string): string {
 }
 
 /**
+ * @catalog-skip - Use color() instead
  * Green text for success
  */
 export function green(text: string): string {
@@ -165,6 +180,7 @@ export function green(text: string): string {
 }
 
 /**
+ * @catalog-skip - Use color() instead
  * Yellow text for warnings
  */
 export function yellow(text: string): string {
@@ -172,6 +188,7 @@ export function yellow(text: string): string {
 }
 
 /**
+ * @catalog-skip - Use color() instead
  * Blue text for info
  */
 export function blue(text: string): string {
@@ -179,6 +196,7 @@ export function blue(text: string): string {
 }
 
 /**
+ * @catalog-skip - Use color() instead
  * Magenta text
  */
 export function magenta(text: string): string {
@@ -186,6 +204,7 @@ export function magenta(text: string): string {
 }
 
 /**
+ * @catalog-skip - Use color() instead
  * Cyan text
  */
 export function cyan(text: string): string {
@@ -193,6 +212,7 @@ export function cyan(text: string): string {
 }
 
 /**
+ * @catalog-skip - Use color() instead
  * Gray text for secondary content
  */
 export function gray(text: string): string {
@@ -204,35 +224,50 @@ export function gray(text: string): string {
 // ============================================================================
 
 /**
- * Format an error message
+ * Format an error message with a red cross icon
+ *
+ * @param message - The error message to format
+ * @returns Formatted string with red ✖ prefix
  */
 export function error(message: string): string {
 	return `${color('red', '✖')} ${message}`
 }
 
 /**
- * Format a success message
+ * Format a success message with a green check icon
+ *
+ * @param message - The success message to format
+ * @returns Formatted string with green ✔ prefix
  */
 export function success(message: string): string {
 	return `${color('green', '✔')} ${message}`
 }
 
 /**
- * Format a warning message
+ * Format a warning message with a yellow caution icon
+ *
+ * @param message - The warning message to format
+ * @returns Formatted string with yellow ⚠ prefix
  */
 export function warning(message: string): string {
 	return `${color('yellow', '⚠')} ${message}`
 }
 
 /**
- * Format an info message
+ * Format an info message with a blue info icon
+ *
+ * @param message - The info message to format
+ * @returns Formatted string with blue ℹ prefix
  */
 export function info(message: string): string {
 	return `${color('blue', 'ℹ')} ${message}`
 }
 
 /**
- * Format a debug message
+ * Format a debug message with a dimmed hexagon icon
+ *
+ * @param message - The debug message to format
+ * @returns Formatted string with dimmed ⬢ prefix and dimmed text
  */
 export function debug(message: string): string {
 	return `${dim('⬢')} ${dim(message)}`
@@ -458,6 +493,7 @@ export function progressBar(
 }
 
 /**
+ * @catalog-skip - Use spinner() instead
  * Spinner frames for loading animations
  */
 export const SPINNER_FRAMES = [
@@ -488,7 +524,7 @@ export function spinner(intervalMs = 80): string {
 // Box drawing
 // ============================================================================
 
-/** Box drawing characters */
+/** @catalog-skip Box drawing characters */
 export const BOX = {
 	topLeft: '┌',
 	topRight: '┐',


### PR DESCRIPTION
## Summary

- Add a postbuild catalog generation script (`scripts/generate-catalog.ts`) that produces four artifacts: `dist/catalog.json`, `dist/catalog.js`, `dist/catalog.d.ts`, and `dist/llms.txt`
- Add `./catalog` (typed JS wrapper) and `./catalog.json` (direct JSON) subpath exports to `package.json`, consumable by both Bun and Node ESM
- Filter catalog to only package.json-declared module exports, preventing accidental dist/src noise from leaking into the catalog

## Test plan

- [x] `bun test scripts/generate-catalog.test.ts` -- 33 unit + integration tests pass
- [x] `bun run validate` -- 1259 tests pass, lint clean, typecheck clean
- [x] `bun run build` -- catalog generated (25 modules, 395 declarations)
- [x] `bun run pack:dry` -- `catalog.json`, `catalog.js`, `catalog.d.ts`, `llms.txt` all present in tarball
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publishable API catalog added with typed JS and direct JSON access via new public export paths.
  * Catalog surfaces structured module summaries, exports, and API documentation for tooling.

* **Tests**
  * Comprehensive test suite added to validate catalog generation, formatting, and JSDoc coverage.

* **Chores**
  * Build now generates catalog artifacts automatically as a post-build step.

* **Documentation**
  * Added doc annotations to exclude legacy/utility items from the catalog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->